### PR TITLE
gprecoverseg: Add RecoveryInfo class

### DIFF
--- a/gpMgmt/bin/gppylib/Makefile
+++ b/gpMgmt/bin/gppylib/Makefile
@@ -23,6 +23,7 @@ DATA= __init__.py \
 	mainUtils.py \
 	parseutils.py \
 	pgconf.py \
+	recoveryinfo.py \
 	userinput.py \
 	utils.py
 

--- a/gpMgmt/bin/gppylib/recoveryinfo.py
+++ b/gpMgmt/bin/gppylib/recoveryinfo.py
@@ -1,0 +1,73 @@
+import datetime
+#TODO: check if pickle is better
+import json
+
+from gppylib import gplog
+
+class RecoveryInfo(object):
+    """
+    This class encapsulates the information needed on a segment host
+    to run full/incremental recovery for a segment.
+
+    Note: we don't have target hostname, since an object of this class will be accessed by the target host directly
+    """
+    def __init__(self, target_datadir, target_port, target_segment_dbid, source_hostname, source_port,
+                 is_full_recovery, progress_file):
+        self.target_datadir = target_datadir
+        self.target_port = target_port
+        self.target_segment_dbid = target_segment_dbid
+
+        # TODO: use address instead of hostname ?
+        self.source_hostname = source_hostname
+        self.source_port = source_port
+        self.is_full_recovery = is_full_recovery
+        self.progress_file = progress_file
+
+    def __str__(self):
+        return json.dumps(self, default=lambda o: o.__dict__)
+
+    def __eq__(self, cmp_recovery_info):
+        return str(self) == str(cmp_recovery_info)
+
+
+def serialize_recovery_info_list(recovery_info_list):
+    return json.dumps(recovery_info_list, default=lambda o: o.__dict__)
+
+def deserialize_recovery_info_list(serialized_string):
+    deserialized_list = json.loads(serialized_string)
+    return [RecoveryInfo(**i) for i in deserialized_list]
+
+def build_recovery_info(mirrors_to_build):
+    """
+    This function is used to format recovery information to send to each segment host
+
+    @param mirrors_to_build:  list of mirrors that need recovery
+
+    @return A dictionary with the following format:
+
+            Key   =   <host name>
+            Value =   list of RecoveryInfos - one RecoveryInfo per segment on that host
+    """
+    timestamp = datetime.datetime.today().strftime('%Y%m%d_%H%M%S')
+
+    recovery_info_by_host = {}
+    for to_recover in mirrors_to_build:
+
+        source_segment = to_recover.getLiveSegment()
+        target_segment = to_recover.getFailoverSegment() or to_recover.getFailedSegment()
+
+        # TODO: move the progress file naming to gpsegrecovery
+        process_name = 'pg_basebackup' if to_recover.isFullSynchronization() else 'pg_rewind'
+        progress_file = '{}/{}.{}.dbid{}.out'.format(gplog.get_logger_dir(), process_name, timestamp,
+                                             target_segment.getSegmentDbId())
+
+        hostname = target_segment.getSegmentHostName()
+
+        if hostname not in recovery_info_by_host:
+            recovery_info_by_host[hostname] = []
+        recovery_info_by_host[hostname].append(RecoveryInfo(
+            target_segment.getSegmentDataDirectory(), target_segment.getSegmentPort(),
+            target_segment.getSegmentDbId(), source_segment.getSegmentHostName(),
+            source_segment.getSegmentPort(), to_recover.isFullSynchronization(),
+            progress_file))
+    return recovery_info_by_host

--- a/gpMgmt/bin/gppylib/test/unit/test_unit_recoveryinfo.py
+++ b/gpMgmt/bin/gppylib/test/unit/test_unit_recoveryinfo.py
@@ -1,0 +1,132 @@
+from mock import call, Mock, patch
+
+from .gp_unittest import GpTestCase
+from gppylib.gparray import Segment
+from gppylib.operations.buildMirrorSegments import GpMirrorToBuild
+from gppylib.recoveryinfo import  build_recovery_info, RecoveryInfo
+
+
+class BuildRecoveryInfoTestCase(GpTestCase):
+    def setUp(self):
+        self.maxDiff = None
+        self.p1 = Segment.initFromString("1|0|p|p|s|u|sdw1|sdw1|1000|/data/primary1")
+        self.p2 = Segment.initFromString("2|1|p|p|s|u|sdw2|sdw2|2000|/data/primary2")
+        self.p3 = Segment.initFromString("3|2|p|p|s|u|sdw2|sdw2|3000|/data/primary3")
+        self.p4 = Segment.initFromString("4|3|p|p|s|u|sdw3|sdw3|4000|/data/primary4")
+
+        self.m1 = Segment.initFromString("5|0|m|m|s|d|sdw2|sdw2|5000|/data/mirror1")
+        self.m2 = Segment.initFromString("6|1|m|m|s|d|sdw1|sdw1|6000|/data/mirror2")
+        self.m3 = Segment.initFromString("7|2|m|m|s|d|sdw3|sdw3|7000|/data/mirror3")
+        self.m4 = Segment.initFromString("8|3|m|m|s|d|sdw3|sdw3|8000|/data/mirror4")
+
+        self.m5 = Segment.initFromString("5|0|m|m|s|d|sdw4|sdw4|9000|/data/mirror5")
+        self.m6 = Segment.initFromString("6|1|m|m|s|d|sdw4|sdw4|10000|/data/mirror6")
+        self.m7 = Segment.initFromString("7|2|m|m|s|d|sdw1|sdw1|11000|/data/mirror7")
+        self.m8 = Segment.initFromString("8|3|m|m|s|d|sdw1|sdw1|12000|/data/mirror8")
+
+
+        self.apply_patches([
+            patch('recoveryinfo.gplog.get_logger_dir', return_value='/tmp/logdir'),
+            patch('recoveryinfo.datetime.datetime')
+        ])
+        self.mock_logdir = self.get_mock_from_apply_patch('get_logger_dir')
+
+
+    def tearDown(self):
+        super(BuildRecoveryInfoTestCase, self).tearDown()
+
+    def test_build_recovery_info_passes(self):
+        # The expected dictionary within each test has target_host as the key.
+        # Each recoveryInfo object holds source_host (live segment), but not the target_host.
+        tests = [
+            {
+                "name": "single_target_host_suggest_full_and_incr",
+                "mirrors_to_build": [GpMirrorToBuild(self.m3, self.p3, None, True),
+                                     GpMirrorToBuild(self.m4, self.p4, None, False)],
+                "expected": {'sdw3': [RecoveryInfo('/data/mirror3', 7000, 7, 'sdw2', 3000,
+                                                   True, '/tmp/logdir/pg_basebackup.111.dbid7.out'),
+                                      RecoveryInfo('/data/mirror4', 8000, 8, 'sdw3', 4000,
+                                                   False, '/tmp/logdir/pg_rewind.111.dbid8.out')]}
+            },
+            {
+                "name": "single_target_hosts_suggest_full_and_incr_with_failover",
+                "mirrors_to_build": [GpMirrorToBuild(self.m1, self.p1, self.m5, True),
+                                     GpMirrorToBuild(self.m2, self.p2, self.m6, False)],
+                "expected": {'sdw4': [RecoveryInfo('/data/mirror5', 9000, 5, 'sdw1', 1000,
+                                                   True, '/tmp/logdir/pg_basebackup.111.dbid5.out'),
+                                      RecoveryInfo('/data/mirror6', 10000, 6, 'sdw2', 2000,
+                                                   True, '/tmp/logdir/pg_basebackup.111.dbid6.out')]}
+            },
+            {
+                "name": "multiple_target_hosts_suggest_full",
+                "mirrors_to_build": [GpMirrorToBuild(self.m1, self.p1, None, True),
+                                     GpMirrorToBuild(self.m2, self.p2, None, True)],
+                "expected": {'sdw2': [RecoveryInfo('/data/mirror1', 5000, 5, 'sdw1', 1000,
+                                                  True, '/tmp/logdir/pg_basebackup.111.dbid5.out')],
+                             'sdw1': [RecoveryInfo('/data/mirror2', 6000, 6, 'sdw2', 2000,
+                                                  True, '/tmp/logdir/pg_basebackup.111.dbid6.out')]}
+            },
+            {
+                "name": "multiple_target_hosts_suggest_full_and_incr",
+                "mirrors_to_build": [GpMirrorToBuild(self.m1, self.p1, None, True),
+                                     GpMirrorToBuild(self.m3, self.p3, None, False),
+                                     GpMirrorToBuild(self.m4, self.p4, None, True)],
+                "expected": {'sdw2': [RecoveryInfo('/data/mirror1', 5000, 5, 'sdw1', 1000,
+                                                   True, '/tmp/logdir/pg_basebackup.111.dbid5.out')],
+                             'sdw3': [RecoveryInfo('/data/mirror3', 7000, 7, 'sdw2', 3000,
+                                                   False, '/tmp/logdir/pg_rewind.111.dbid7.out'),
+                                      RecoveryInfo('/data/mirror4', 8000, 8, 'sdw3', 4000,
+                                                   True, '/tmp/logdir/pg_basebackup.111.dbid8.out')]}
+            },
+            {
+                "name": "multiple_target_hosts_suggest_incr_failover_same_as_failed",
+                "mirrors_to_build": [GpMirrorToBuild(self.m1, self.p1, self.m1, False),
+                                     GpMirrorToBuild(self.m2, self.p2, self.m2, False)],
+                "expected": {'sdw2': [RecoveryInfo('/data/mirror1', 5000, 5, 'sdw1', 1000,
+                                                  True, '/tmp/logdir/pg_basebackup.111.dbid5.out')],
+                             'sdw1': [RecoveryInfo('/data/mirror2', 6000, 6, 'sdw2', 2000,
+                                                  True, '/tmp/logdir/pg_basebackup.111.dbid6.out')]}
+            },
+            {
+                "name": "multiple_target_hosts_suggest_full_failover_same_as_failed",
+                "mirrors_to_build": [GpMirrorToBuild(self.m1, self.p1, self.m1, True),
+                                     GpMirrorToBuild(self.m3, self.p3, self.m3, True),
+                                     GpMirrorToBuild(self.m4, self.p4, None, True)],
+                "expected": {'sdw2': [RecoveryInfo('/data/mirror1', 5000, 5, 'sdw1', 1000,
+                                                  True, '/tmp/logdir/pg_basebackup.111.dbid5.out')],
+                             'sdw3': [RecoveryInfo('/data/mirror3', 7000, 7, 'sdw2', 3000,
+                                                   True, '/tmp/logdir/pg_basebackup.111.dbid7.out'),
+                                      RecoveryInfo('/data/mirror4', 8000, 8, 'sdw3', 4000,
+                                                   True, '/tmp/logdir/pg_basebackup.111.dbid8.out')]}
+            },
+            {
+                "name": "multiple_target_hosts_suggest_full_and_incr",
+                "mirrors_to_build": [GpMirrorToBuild(self.m1, self.p1, self.m5, True),
+                                     GpMirrorToBuild(self.m2, self.p2, None, False),
+                                     GpMirrorToBuild(self.m3, self.p3, self.m3, False),
+                                     GpMirrorToBuild(self.m4, self.p4, self.m8, True)],
+                "expected": {'sdw4': [RecoveryInfo('/data/mirror5', 9000, 5, 'sdw1', 1000,
+                                                   True, '/tmp/logdir/pg_basebackup.111.dbid5.out'),
+                                      ],
+                             'sdw1': [RecoveryInfo('/data/mirror2', 6000, 6,
+                                                   'sdw2', 2000, False,
+                                                   '/tmp/logdir/pg_rewind.111.dbid6.out'),
+                                      RecoveryInfo('/data/mirror8', 12000, 8,
+                                                   'sdw3', 4000, True,
+                                                   '/tmp/logdir/pg_basebackup.111.dbid8.out')],
+                             'sdw3': [RecoveryInfo('/data/mirror3', 7000, 7, 'sdw2', 3000,
+                                                   True, '/tmp/logdir/pg_basebackup.111.dbid7.out')]
+                             }
+            },
+
+        ]
+        self.run_tests(tests)
+
+    def run_tests(self, tests):
+        for test in tests:
+            with self.subTest(msg=test["name"]):
+                self.mock_datetime = self.get_mock_from_apply_patch('datetime')
+                self.mock_datetime.today.return_value.strftime = Mock(side_effect=['111', '222'])
+                actual_ri_by_host = build_recovery_info(test['mirrors_to_build'])
+                self.assertEqual(test['expected'], actual_ri_by_host)
+                self.mock_datetime.today.return_value.strftime.assert_called_once()


### PR DESCRIPTION
This class encapsulates the information needed on a segment host
to run full/incremental recovery for a segment. This information can
be serialized and sent over to the segment hosts that need to run either
full or incremental recovery.

This would replace gp.ConfigureNewSegment.buildSegmentInfoForNewSegment
which was harder to read, and had a lot of code which was not needed for
recovery.

Co-Authored-by: Nikhil Kak <nkak@vmware.com>

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
